### PR TITLE
Feat: id129/approval email

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>6.1.0</version>

--- a/src/main/java/com/pardal/app/AppApplication.java
+++ b/src/main/java/com/pardal/app/AppApplication.java
@@ -2,12 +2,14 @@ package com.pardal.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class AppApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(AppApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(AppApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/pardal/app/controllers/AuthenticatorController.java
+++ b/src/main/java/com/pardal/app/controllers/AuthenticatorController.java
@@ -27,15 +27,31 @@ public class AuthenticatorController {
 
     @Operation(summary = "Cadastro de Usuário")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Usuário cadastrado com sucesso."),
+            @ApiResponse(responseCode = "201", description = "Usuário pré-cadastrado com sucesso."),
             @ApiResponse(responseCode = "400", description = "Requisição mal formulada."),
             @ApiResponse(responseCode = "408", description = "Tempo de resposta excedido."),
-            @ApiResponse(responseCode = "500", description = "Erro interno do servidor no cadastro de usuário.")
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor no pré cadastro de usuário.")
     })
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequestDto request) {
         return RequestExceptionHandler.handleRequest("Registro de usuário", () -> {
             ResponseUserCreatedDto response = authService.signup(request);
+            log.info("Usuário com email: {} foi pré-registrado com sucesso", response.getEmail());
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        });
+    }
+
+    @Operation(summary = "Aprovação do Cadastro do usuário")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Usuário cadastrado com sucesso."),
+            @ApiResponse(responseCode = "400", description = "Requisição mal formulada."),
+            @ApiResponse(responseCode = "408", description = "Tempo de resposta excedido."),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor no cadastro de usuário.")
+    })
+    @PatchMapping("/approval/{userId}")
+    public ResponseEntity<?> approval(@PathVariable Integer userId) {
+        return RequestExceptionHandler.handleRequest("Registro de usuário", () -> {
+            ResponseUserCreatedDto response = authService.approval(userId);
             log.info("Usuário com email: {} foi registrado com sucesso", response.getEmail());
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         });

--- a/src/main/java/com/pardal/app/mail/EmailService.java
+++ b/src/main/java/com/pardal/app/mail/EmailService.java
@@ -1,56 +1,117 @@
 package com.pardal.app.mail;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import org.thymeleaf.context.Context;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 public class EmailService {
 
-    @Autowired
-    private JavaMailSender mailSender;
+    private final String SUBJECT_PRE_REGISTRATION = "Pré-cadastro na plataforma Pardal!";
+    private final String PRE_REGISTRATION_TEMPLATE = "pre-registration";
+    private final String SUBJECT_APPROVAL_REGISTRATION = "Seu Cadastro Pardal foi Aprovado!";
+    private final String APPROVAL_TEMPLATE = "approval";
+    private final String UTF_8 = "UTF-8";
+    private final String PARDAL_IMAGE="images/logo.png";
 
-    @Value("${spring.mail.username}")
-    private String sender;
+    private final JavaMailSender mailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final String sender;
+    private final String baseUrl;
 
-    public String sendValidationEmail(String recipient, String token) {
-        String baseUrl = "http://localhost:5173";
-        String verificationUrl = baseUrl + "/verify-email/" + token;
+    public EmailService(
+            JavaMailSender mailSender,
+            SpringTemplateEngine templateEngine,
+            @Value("${spring.mail.username}") String sender,
+            @Value("${app.base-url}") String baseUrl) {
 
-        String subject = "Confirmação do seu cadastro na plataforma Pardal!";
+        this.mailSender = mailSender;
+        this.templateEngine = templateEngine;
+        this.sender = sender;
+        this.baseUrl = baseUrl;
+    }
 
-        String htmlContent = """
-    <html>
-        <body>
-            <img src="cid:logo" alt="Logo" style="width: 150px; height: auto;">
-            <h1>Bem-vindo à plataforma Pardal!</h1>
-            <p>Olá, clique <a href="%s">aqui</a> para confirmar seu e-mail.</p>
-        </body>
-    </html>
-    """.formatted(verificationUrl);
+    /**
+    * Constructs and sends an email using Thymeleaf template processing.
+    * This method handles setting up the MIME message, embedding the logo image,
+    * and sending the email via JavaMailSender.
+    *
+    * @param recipient the address to send the email to
+    * @param subject the subject line of the email
+    * @param templateName the name of the Thymeleaf template file (e.g., "email/template-name")
+    * @param variables a map of data variables to be processed by the template
+    * @author paulo arantes
+    * @throws MessagingException if the message could not be created or sent
+    */
+    private void sendEmail(String recipient, String subject, String templateName, Map<String, Object> variables) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, UTF_8); 
 
+        Context context = new Context();
+        context.setVariables(variables);
+
+        String htmlContent = templateEngine.process(templateName, context); 
+
+        helper.setSubject(subject);
+        helper.setText(htmlContent, true);
+        helper.setTo(recipient);
+        helper.setFrom(sender);
+
+        ClassPathResource image = new ClassPathResource(PARDAL_IMAGE);
+        helper.addInline("logo", image);
+
+        mailSender.send(message);
+    }
+
+    /**
+     * Sends the user pre-registration email asynchronously.
+     *
+     * @param recipient the email address of the recipient
+     * @author paulo arantes
+     * @return a CompletableFuture representing the completion of the email sending process
+     */
+    @Async
+    public void sendPreRegistrationEmail(String recipient) {
         try {
-            MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-            helper.setSubject(subject);
-            helper.setText(htmlContent, true);
-            helper.setTo(recipient);
-            helper.setFrom(sender);
-
-            ClassPathResource image = new ClassPathResource("images/logo.png");
-            helper.addInline("logo", image);
-
-            mailSender.send(message);
-            return "Email sent successfully!";
+            sendEmail(recipient, SUBJECT_PRE_REGISTRATION, PRE_REGISTRATION_TEMPLATE, Map.of());
+            log.info("Email de pré-cadastro enviado com sucesso!");
         } catch (MessagingException e) {
-            e.printStackTrace();
-            return "Error sending email.";
+            log.info("Erro ao enviar email de pré-cadastro.");
+            e.getStackTrace();
+        }
+    }
+
+    /**
+     * Sends the user approval email asynchronously.
+     *
+     * @param recipient the email address of the recipient
+     * @author paulo arantes
+     * @return a CompletableFuture representing the completion of the email sending process
+     */
+    @Async
+    public void sendApprovalEmail(String recipient) {
+        try {
+            String loginUrl = baseUrl;
+            Map<String, Object> variables = Map.of(
+                    "loginUrl", loginUrl
+                    );
+            sendEmail(recipient, SUBJECT_APPROVAL_REGISTRATION, APPROVAL_TEMPLATE, variables);
+            log.info("Email de aprovação enviado com sucesso!");
+        } catch (MessagingException e) {
+            log.info("Erro ao enviar email de aprovação.");
+            e.getStackTrace();
         }
     }
 }

--- a/src/main/java/com/pardal/app/service/appUser/AppUserService.java
+++ b/src/main/java/com/pardal/app/service/appUser/AppUserService.java
@@ -13,6 +13,7 @@ import com.pardal.app.repository.AppUserRepository;
 import com.pardal.app.repository.UserRepository;
 import com.pardal.app.repository.logging.LogEntryRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -174,9 +175,42 @@ public class AppUserService implements UserDetailsService {
                 .build();
 
         AppUser newUser = userRepository.save(appUser);
-        emailService.sendValidationEmail(newUser.getEmail(), newUser.getVerificationToken());
-
+        emailService.sendPreRegistrationEmail(newUser.getEmail());
         return convertUserToDto(userRepository.save(appUser));
+    }
+
+    /**
+     * Approves a user, sets their email as verified, and asynchronously sends the approval email.
+     *
+     * @param appUserId the ID of the user to be approved
+     * @author paulo arantes
+     * @return an AppUserDto representing the approved user
+     */
+    @Transactional
+    public AppUserDto approvalUser(Integer appUserId) {
+        AppUser user =  getUserAllAttributes(appUserId);
+        user.setEmailVerified(true);
+        user.setExpireDate(null);
+        emailService.sendApprovalEmail(user.getEmail());
+        return convertUserToDto(user);
+    }
+
+    /**
+     * Retrieves an AppUser from the repository by ID.
+     *
+     * @param userId the ID of the user to retrieve
+     * @return the AppUser object if found
+     * @author paulo arantes
+     * @throws NoSuchElementException if a user with the given ID does not exist
+     */
+    private AppUser getUserAllAttributes(Integer userId)
+    {
+        Optional<AppUser> user = appUserRepository.findById(userId);
+        if (user.isEmpty()) {
+            log.error("Usuario com id: "+userId+" não existe");
+            throw new NoSuchElementException();
+        }
+        return user.get();
     }
 
     /**

--- a/src/main/java/com/pardal/app/service/auth/AuthService.java
+++ b/src/main/java/com/pardal/app/service/auth/AuthService.java
@@ -9,4 +9,5 @@ public interface AuthService {
     ResponseUserCreatedDto signup(SignupRequestDto request);
     ResponseUserCreatedDto verify(String token);
     JwtAuthenticationResponseDto login(LoginRequestDto request);
+    ResponseUserCreatedDto approval(Integer userId);
 }

--- a/src/main/java/com/pardal/app/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/pardal/app/service/auth/AuthServiceImpl.java
@@ -7,7 +7,6 @@ import com.pardal.app.entity.dto.auth.LoginRequestDto;
 import com.pardal.app.entity.dto.auth.ResponseUserCreatedDto;
 import com.pardal.app.entity.dto.auth.SignupRequestDto;
 import com.pardal.app.exceptions.AppUserNotFoundException;
-import com.pardal.app.repository.AppRoleRepository;
 import com.pardal.app.service.JwtService;
 import com.pardal.app.service.appUser.AppUserService;
 import jakarta.transaction.Transactional;
@@ -15,16 +14,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
 
-    private PasswordEncoder passwordEncoder;
     private final AppUserService appUserService;
-    private AppRoleRepository appRoleRepository;
     private final JwtService jwtService;
     private final AuthenticationManager authenticationManager;
 
@@ -151,5 +147,26 @@ public class AuthServiceImpl implements AuthService {
         {
             throw new IllegalArgumentException(fieldName + " cannot be null or blank");
         }
+    }
+
+    /**
+     * Orchestrates the user approval process by calling the application service
+     * and mapping the result to a response DTO.
+     *
+     * @param userId the ID of the user to be approved
+     * @author paulo arantes
+     * @return a ResponseUserCreatedDto containing the details of the newly approved user
+     */
+    @Override
+    public ResponseUserCreatedDto approval (Integer userId)
+    {
+        AppUserDto registeredUser =  appUserService.approvalUser(userId);
+
+        return new ResponseUserCreatedDto(
+                registeredUser.getId(),
+                registeredUser.getName(),
+                registeredUser.getEmail(),
+                registeredUser.getRole().getRlName()
+        );
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.data.mongodb.db2.uri=mongodb://mongoadmin:secret@localhost:27017/audit_db
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=manolito.pardal@gmail.com
+app.base-url=http://localhost:5173/
 spring.mail.password=ppib asja wkbm yttl
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/templates/approval.html
+++ b/src/main/resources/templates/approval.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-br" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+    <img th:src="@{cid:logo}" alt="Logo" style="width: 150px; height: auto;">
+    <h1>🎉 Cadastro Aprovado na Plataforma Pardal!</h1>
+    <p>Olá!</p>
+    <p>Temos o prazer de informar que seu cadastro foi aprovado pelo administrador.</p>
+    <p>Sua conta está agora disponível para uso. Você pode acessá-la clicando no link abaixo:</p>
+    <p>
+        <a th:href="${loginUrl}">Acessar a Plataforma Pardal</a>
+    </p>
+    <p>Boas-vindas!</p>
+</body>
+</html>

--- a/src/main/resources/templates/pre-registration.html
+++ b/src/main/resources/templates/pre-registration.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="pt-br" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+    <img th:src="@{cid:logo}" alt="Logo" style="width: 150px; height: auto;">
+    <h1>Bem-vindo(a) à plataforma Pardal!</h1>
+    <p>Olá! Seu pré-cadastro foi realizado com sucesso.</p>
+    <p>No entanto, a aprovação do administrador é necessária para que você possa acessar a plataforma.</p>
+    <p>Assim que o seu cadastro for aprovado, você receberá um novo e-mail informando que sua conta está disponível para uso.</p>
+    <p>Agradecemos a compreensão.</p>
+</body>
+</html>


### PR DESCRIPTION
Upon account creation, the user immediately receives a pre-registration email informing them that their account is pending and requires manual administrator approval before platform access is granted.

Once the administrator completes the approval, the user will receive a second email, confirming their registration has been approved and that they can now use the platform.

A new HTTP endpoint was created to manage this approval process:

http://<HOST>:<PORT>/auth/approval/{userId}

This endpoint must be accessed by the administrator to finalize the user activation process.